### PR TITLE
Fix buffer handling issues

### DIFF
--- a/TTS.cpp
+++ b/TTS.cpp
@@ -20,7 +20,7 @@ static byte seed2;
 
 static char phonemes[128];
 static char modifier[128];	// must be same size as 'phonemes'
-static char g_text[64];
+static char g_text[128];
 
 static byte defaultPitch = 7;
 
@@ -159,7 +159,7 @@ static int textToPhonemes(const char *src, const VOCAB * vocab, char *dest)
 	}
 	// 20
 	outIndex += numOut;
-	if (outIndex > 256 - 16) {
+	if (outIndex > 128 - 16) {
 	    //loggerP(PSTR("Mistake in SAY, text too long\n"));
 	    return 0;
 	}
@@ -689,14 +689,7 @@ void TTS::sayPhonemes(const char *textp)
 void TTS::sayText(const char *original)
 {
     unsigned int i;
-    if (textToPhonemes(original, s_vocab, phonemes)) {
-	// copy string from phonemes to text 
-	for (i = 0; phonemes[i]; i++)
-	    g_text[i] = phonemes[i];
-
-	while (i < sizeof(g_text))
-	    g_text[i++] = 0;
-
+    if (textToPhonemes(original, s_vocab, g_text)) {  
 	sayPhonemes(g_text);
     }
 }


### PR DESCRIPTION
The first bug was that sayText was copying a buffer of up to 112 bytes into a buffer of size 64 (g_text).  Fixed it by changing g_text to 128 bytes, plus we don't need to copy the buffer, we can just let textToPhonemes fill the buffer for us.

The next bug was a line of code was checking to see if we'd written 256-16 bytes to a buffer.  All buffers are 128 bytes, so I changed it to 128-16.

Note that in general this code is likely to produce no output if the input sentence is larger than about 50 to 60 characters (since the final phoneme data will end up being more than 112 characters which is the limit).  There's no easy way to know until after all the processing is done.  Probably worth calling that out somewhere.